### PR TITLE
192 - Support BitBucket

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -79,7 +79,7 @@ class Server < Sinatra::Base
 
     data = JSON.parse(decoded, :quirks_mode => true)
 
-    module_name = ( data['repository']['name'] || data['pullrequest_merged']['destination']['repository']['name'] ).sub(/^.*-/, '')
+    module_name = ( data['repository']['name'] rescue nil || data['pullrequest_merged']['destination']['repository']['name'] ).sub(/^.*-/, '')
 
     deploy_module(module_name)
   end
@@ -108,7 +108,7 @@ class Server < Sinatra::Base
     data = JSON.parse(decoded, :quirks_mode => true)
 
     # github sends a 'ref', stash sends an array in 'refChanges'
-    branch = ( data['ref'] || data['refChanges'][0]['refId'] || data['pullrequest_merged']['destination']['branch']['name'] ).sub('refs/heads/', '')
+    branch = ( data['ref'] || data['refChanges'][0]['refId'] rescue nil || data['pullrequest_merged']['destination']['branch']['name'] ).sub('refs/heads/', '')
 
     # If prefix is enabled in our config file run the command to determine the prefix
     if $config['prefix']


### PR DESCRIPTION
In the OR logic clause for parsing the JSON hash, the code was throwing NoMethodError
for accessing hash levels deeper than the first that did not exist. This was causing
the code to prematurely exit.

I added an inline rescue to rewrite it as nil to progress to the next step in the
OR logic clause wherever this could happen.
